### PR TITLE
configury: improve xpmem config check

### DIFF
--- a/config/sandia_check_xpmem.m4
+++ b/config/sandia_check_xpmem.m4
@@ -21,9 +21,12 @@ AC_DEFUN([SANDIA_CHECK_XPMEM], [
   saved_LIBS="$LIBS"
   AS_IF([test ! -z "$with_xpmem" -a "$with_xpmem" != "yes"],
     [CPPFLAGS="$CPPFLAGS -I$with_xpmem/include"
-     LDFLAGS="$LDFLAGS -L$with_xpmem/lib"
      XPMEM_CPPFLAGS="-I$with_xpmem/include"
-     XPMEM_LDFLAGS="-L$with_xpmem/lib"])
+     AS_IF([test -d "$with_with_xpmem/lib64"],
+             [LDFLAGS="$LDFLAGS -L$with_xpmem/lib64"
+              XPMEM_LDFLAGS="-L$with_xpmem/lib64"],
+             [LDFLAGS="$LDFLAGS -L$with_xpmem/lib"
+              XPMEM_LDFLAGS="-L$with_xpmem/lib"])])
 
   AS_IF([test "$happy" = "yes"], 
     [AC_CHECK_HEADERS([xpmem.h], [], [happy=no])])


### PR DESCRIPTION
On some systems, the xpmem library is
installed in a lib64 rather than lib
subdir of the top level xpmem install.
Enhance the configury check to look for
either subdir.

@jdinan 

Signed-off-by: Howard Pritchard howardp@lanl.gov
