### PR TITLE
Fix include for missing declaration of shmem_internal_trap_on_abort

### DIFF
--- a/src/runtime-pmi2.c
+++ b/src/runtime-pmi2.c
@@ -33,7 +33,7 @@
 #define PMI2_SUCCESS 0
 #endif
 
-#include "runtime.h"
+#include "shmem_internal.h"
 
 static int rank = -1;
 static int size = 0;


### PR DESCRIPTION
Compiling yields the following error message:

runtime-pmi2.c(144): error: identifier "shmem_internal_trap_on_abort" is undefined
      if (shmem_internal_trap_on_abort)

Looks like this extern is defined in shmem_internal.h, so hope this is the appropriate change to make.