### PR TITLE
Missing shmemx include in performance tests

### DIFF
--- a/test/performance/shmem_perf_suite/shmem_bw_put_ctx_lockless.c
+++ b/test/performance/shmem_perf_suite/shmem_bw_put_ctx_lockless.c
@@ -38,6 +38,7 @@
 #include <assert.h>
 #include <omp.h>
 #include <unistd.h>
+#include <shmemx.h>
 
 int n_threads, n_dom;
 shmemx_domain_t* doms;


### PR DESCRIPTION
Thanks for integrating that other fix!

Quick other thing I noticed while compiling the perf tests, it looks like the existing context perf tests are missing a shmemx.h include?