### PR TITLE
Fix problem with releasing domains

### DIFF
--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -296,6 +296,7 @@ static int shmem_transport_ofi_domain_init(int id, int thread_level,
     int ret;
 
     dom->id = id;
+    dom->refcnt = 1;
     dom->freed = 0;
     dom->num_active_contexts = 0;
 
@@ -383,6 +384,7 @@ int shmem_transport_domain_create(int thread_level, int num_domains,
             shmem_transport_ofi_domains[id] = dom;
             domains[i] = dom;
             shmem_transport_ofi_num_dom++;
+            dom->refcnt++;
         }
     }
 
@@ -395,7 +397,7 @@ int shmem_transport_domain_create(int thread_level, int num_domains,
 // assumes dom->lock is locked or dom->use_lock == 0
 static void shmem_transport_ofi_domain_free(shmem_transport_domain_t* dom)
 {
-    int ret;
+    int ret = FI_SUCCESS;
 
     // The attached CQ is implicitly closed (as I discovered while
     // memory-checking with Valgrind). -jpdoyle
@@ -409,21 +411,24 @@ static void shmem_transport_ofi_domain_free(shmem_transport_domain_t* dom)
                    dom->num_active_contexts);
     }
 
-    ret = fi_close(&dom->stx->fid);
+    if (0 == --(dom->refcnt)) {
 
-    if (ret) {
-        OFI_ERRMSG("Domain STX close failed (%s)", fi_strerror(errno));
+        ret = fi_close(&dom->stx->fid);
+        if (ret) {
+            OFI_ERRMSG("Domain STX close failed (%s)", fi_strerror(errno));
+        }
+
+        dom->freed = 1;
+        dom->release_lock(&dom);
+        dom->free_lock(&dom);
+        if (dom->id >= 0) {
+            shmem_transport_ofi_domains[dom->id] = NULL;
+        }
+
+    } else {
+        dom->release_lock(&dom);
     }
 
-    dom->freed = 1;
-    dom->release_lock(&dom);
-    dom->free_lock(&dom);
-
-    /* FIXME: add to free list, maybe? */
-    if (dom->id >= 0) {
-        shmem_transport_ofi_domains[dom->id] = NULL;
-        free(dom);
-    }
 }
 
 
@@ -1347,6 +1352,7 @@ int shmem_transport_fini(void)
       if(dom) {
         dom->take_lock(&dom);
         shmem_transport_ofi_domain_free(dom);
+        if (dom->freed) free(dom);
       }
     }
 

--- a/src/transport_ofi.h
+++ b/src/transport_ofi.h
@@ -87,6 +87,7 @@ typedef struct shmem_transport_cntr_ep_t {
 
 typedef struct shmem_transport_domain_t {
   int id;
+  int refcnt;
   struct fid_stx* stx;
 #ifdef ENABLE_THREADS
   shmem_internal_mutex_t lock;


### PR DESCRIPTION
The way domains are being used for contexts, etc.
we need a refcnt as pointers to dom's are turned
to the app, which then is suppose to free them.
At the same time, dom's are also used internally
in SOS.  This kind of thing needs to use ref counts
to avoid possible multiple attempts to free underlying
resources associated with a dom struct.

With this commit, the ctx test now passes using the
GNI provider.

@jdinan 

Signed-off-by: Howard Pritchard <howardp@lanl.gov>